### PR TITLE
panther2 fixes

### DIFF
--- a/src/Panther.StdLib/Predef.cs
+++ b/src/Panther.StdLib/Predef.cs
@@ -15,4 +15,9 @@ public static class Predef
     private static Random _random = new Random();
 
     public static int rnd(int max) => _random.Next(max);
+
+    public static void panic() => throw new InvalidOperationException("panicked");
+
+    public static void panic(object value) =>
+        throw new InvalidOperationException($"panicked: {value}");
 }

--- a/src/Panther/CodeAnalysis/DiagnosticBag.cs
+++ b/src/Panther/CodeAnalysis/DiagnosticBag.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 using Panther.CodeAnalysis.Symbols;
 using Panther.CodeAnalysis.Syntax;
 using Panther.CodeAnalysis.Text;
+using Panther.CodeAnalysis.Typing;
 
 namespace Panther.CodeAnalysis;
 
@@ -30,7 +31,7 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public void ReportInvalidNumber(TextLocation textSpan, string text, Type type) =>
-        Report(textSpan, $"The number {text} isn't a valid '{type}'");
+        Report(textSpan, $"The number {text} isn't a valid '{type.ToPrintString()}'");
 
     public void ReportInvalidEscapeSequence(TextLocation location, in char current) =>
         Report(location, $"Invalid character in escape sequence: {current}");
@@ -57,7 +58,7 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
     ) =>
         Report(
             location,
-            $"Unary operator '{operatorText}' is not defined for type '{operandType}'"
+            $"Unary operator '{operatorText}' is not defined for type '{operandType.ToPrintString()}'"
         );
 
     public void ReportUndefinedBinaryOperator(
@@ -68,7 +69,7 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
     ) =>
         Report(
             location,
-            $"Binary operator '{operatorText}' is not defined for types '{leftType}' and '{rightType}'"
+            $"Binary operator '{operatorText}' is not defined for types '{leftType.ToPrintString()}' and '{rightType.ToPrintString()}'"
         );
 
     public void ReportUndefinedName(TextLocation location, string name) =>
@@ -81,7 +82,10 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, $"Reassignment to val '{name}'");
 
     public void ReportTypeMismatch(TextLocation location, Type expectedType, Type foundType) =>
-        Report(location, $"Type mismatch. Required '{expectedType}', found '{foundType}'");
+        Report(
+            location,
+            $"Type mismatch. Required '{expectedType.ToPrintString()}', found '{foundType.ToPrintString()}'"
+        );
 
     public void ReportExpectedExpression(TextLocation location, SyntaxKind kind) =>
         Report(location, $"Unexpected token {kind}, expected Expression");
@@ -116,12 +120,15 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
         );
 
     public void ReportCannotConvert(TextLocation location, Type fromType, Type toType) =>
-        Report(location, $"Cannot convert from '{fromType}' to '{toType}'");
+        Report(
+            location,
+            $"Cannot convert from '{fromType.ToPrintString()}' to '{toType.ToPrintString()}'"
+        );
 
     public void ReportCannotConvertImplicitly(TextLocation location, Type fromType, Type toType) =>
         Report(
             location,
-            $"Cannot convert from '{fromType}' to '{toType}'. An explicit conversion exists, are you missing a cast?"
+            $"Cannot convert from '{fromType.ToPrintString()}' to '{toType.ToPrintString()}'. An explicit conversion exists, are you missing a cast?"
         );
 
     public void ReportUndefinedTypeOrInitializer(TextLocation location) =>
@@ -173,7 +180,7 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
         Report(location, $"Duplicate type '{typeName}' detected");
 
     public void ReportMissingDefinition(TextLocation location, Type type, string name) =>
-        Report(location, $"'{type.Symbol.Name}' does not contain a definition for '{name}'");
+        Report(location, $"'{type.ToPrintString()}' does not contain a definition for '{name}'");
 
     public void ReportInvalidReference(string reference) =>
         Report(null, $"The specified reference is not valid: {reference}");
@@ -247,4 +254,7 @@ internal sealed class DiagnosticBag : IEnumerable<Diagnostic>
 
     public void ReportArrayOnlyRankOrInitializer(TextLocation location) =>
         Report(location, "Array cannot provide rank and initializer");
+
+    public void ReportGenericTypeNotSupported(TextLocation location, string typeName) =>
+        Report(location, $"Generic type not supported: {typeName}");
 }

--- a/src/Panther/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Panther/CodeAnalysis/Emit/Emitter.cs
@@ -733,7 +733,7 @@ internal class Emitter
         Assert(node.Expressions.Length == 0);
         Assert(node.ArraySize != null);
 
-        var arrayType = LookupType(node.Type.Symbol);
+        var arrayType = LookupType(((ArrayType)node.Type).ElementType.Symbol);
 
         EmitExpression(processor, node.ArraySize!);
         processor.Emit(OpCodes.Newarr, arrayType);

--- a/src/Panther/CodeAnalysis/Emit/Emitter.cs
+++ b/src/Panther/CodeAnalysis/Emit/Emitter.cs
@@ -1015,8 +1015,7 @@ internal class Emitter
                 return;
             }
         }
-
-        if (toType == Type.Any)
+        else if (toType == Type.Any)
         {
             if (fromType == Type.Bool)
             {
@@ -1050,14 +1049,18 @@ internal class Emitter
                 return;
             }
         }
-
-        if (toType == Type.Int)
+        else if (toType == Type.Int)
         {
             if (fromType == Type.String)
             {
                 ilProcessor.Emit(OpCodes.Call, _convertToInt32);
                 return;
             }
+        }
+        else if (toType == Type.Char && fromType == Type.Int)
+        {
+            // conversion is a no-op
+            return;
         }
 
         throw new ArgumentOutOfRangeException(

--- a/src/Panther/CodeAnalysis/Symbols/SymbolPrinter.cs
+++ b/src/Panther/CodeAnalysis/Symbols/SymbolPrinter.cs
@@ -6,6 +6,13 @@ namespace Panther.CodeAnalysis.Symbols;
 
 internal static class SymbolPrinter
 {
+    public static string ToPrintString(this Type type)
+    {
+        using var writer = new StringWriter();
+        type.WriteTo(writer);
+        return writer.ToString();
+    }
+
     public static void WriteTo(this Type symbol, TextWriter writer)
     {
         switch (symbol)

--- a/src/Panther/CodeAnalysis/Text/TextLocation.cs
+++ b/src/Panther/CodeAnalysis/Text/TextLocation.cs
@@ -23,7 +23,7 @@ public class TextLocation : IEquatable<TextLocation>
     {
         get
         {
-            var offset = File.LineToOffset(StartLine);
+            var offset = File.LineToOffset(EndLine);
             return offset == -1 ? -1 : Span.End - offset;
         }
     }

--- a/src/Panther/CodeAnalysis/Typing/Conversion.cs
+++ b/src/Panther/CodeAnalysis/Typing/Conversion.cs
@@ -35,6 +35,9 @@ internal abstract record Conversion
         if (from == Type.Any)
             return Explicit;
 
+        if (from == Type.Int && to == Type.Char)
+            return Explicit;
+
         if ((from == Type.Bool || from == Type.Int || from == Type.Char) && to == Type.String)
             return Explicit;
 

--- a/src/Panther/CodeAnalysis/Typing/Typer.cs
+++ b/src/Panther/CodeAnalysis/Typing/Typer.cs
@@ -199,7 +199,7 @@ internal sealed class Typer
 
         if (_constructorBodies.TryGetValue(ctorSymbol, out var existingBody))
         {
-            boundStatements.Add(new TypedExpressionStatement(parent, existingBody));
+            boundStatements.Insert(0, new TypedExpressionStatement(parent, existingBody));
         }
 
         var loweredBody = LoweringPipeline.Lower(

--- a/src/Panther/CodeAnalysis/Typing/Typer.cs
+++ b/src/Panther/CodeAnalysis/Typing/Typer.cs
@@ -1571,6 +1571,7 @@ internal sealed class Typer
             ["any"] = Type.Any,
             ["int"] = Type.Int,
             ["bool"] = Type.Bool,
+            ["char"] = Type.Char,
             ["string"] = Type.String,
             ["unit"] = Type.Unit,
         };


### PR DESCRIPTION
- Improve error reporting for types
- Add a way to crash a program, useful for debugging
- Fix issue with array instantiation
- Add support for conversion from int to char
- Fix an issue with TextLocation.EndCharacter
- Update constructors to initialize primary constructor parameters first
- Fix an issue where an Apply type may not be resolved
