### PR TITLE
fix(test): tests fail if dotnet isnt on the path

### DIFF
--- a/tests/Panther.Tests/CodeAnalysis/Dotnet.cs
+++ b/tests/Panther.Tests/CodeAnalysis/Dotnet.cs
@@ -106,6 +106,14 @@ class Dotnet
                 return exeFullPath;
         }
 
+        // Ok we cant find it on the path lets just take some guesses
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            var homebrew = "/usr/local/share/dotnet/dotnet";
+            if (File.Exists(homebrew))
+                return homebrew;
+        }
+
         throw new ArgumentException("Could not find `dotnet` executable");
     }
 }


### PR DESCRIPTION
fix(test): tests fail if dotnet isnt on the path

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/kthompson/panther/pull/46).
* #47
* __->__ #46